### PR TITLE
Doc updates by TW

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -2,19 +2,20 @@
 
 Built to accommodate a wide range of use cases, this Terraform module can deploy both simple and complex Amazon Virtual Private Cloud (Amazon VPC) IP Address Manager (IPAM) configurations. It supports both symmetrically nested, multi-Region deployments (most common IPAM designs) as well as [asymmetically nested deployments](images/asymmetrical_example.png).
 
-Refer to the [examples/](./examples/) directory in this GitHub repository for examples. 
+Refer to the [examples/](./examples/) directory in this GitHub repository for examples.
 
-This document describes a symmetrically nested pool structure, including its configuration, implementation details, examples for importing, requirements, and more. 
+The embedded example below describes a symmetrically nested pool structure, including its configuration, implementation details, requirements, and more.
+
 ## Architecture
 
 ![symmetrically nested pool deployment](images/ipam_symmetrical.png) "Region Separated Pools")
 
-## Configuration 
-This module strongly relies on the `var.pool_configuration` variable, which is a multi-level, nested map that describes how to nest your IPAM pools. It can accept most `aws_vpc_ipam_pool` and `aws_vpc_ipam_pool_cidr` attributes (detailed below) as well as RAM share pools (at any level) to valid AWS principals. Nested pools do not inherit attributes from their source pool(s), so all configuration options are available at each level.
+## Configuration
+This module strongly relies on the `var.pool_configuration` variable, which is a multi-level, nested map that describes how to nest your IPAM pools. It can accept most `aws_vpc_ipam_pool` and `aws_vpc_ipam_pool_cidr` attributes (detailed below) as well as RAM share pools (at any level) to valid AWS principals. Nested pools do not inherit attributes from their source pool(s), so all configuration options are available at each level. `locale` is implied in sub pools after declared in a parent.
 
 In this module, pools can be nested up to four levels, including one root pool and up to three nested pools. The root pool defines the `address_family` variable. If you want to deploy an IPv4 and IPv6 pool structure, you must instantiate the module for each type.
 
-The `pool_configurations` variable is the structure of the other three levels. The `sub_pool` submodule has a `var.pool_config` variable that defines the structure that each pool can accept. The variable has the following structure: 
+The `pool_configurations` variable is the structure of the other three levels. The `sub_pool` submodule has a `var.pool_config` variable that defines the structure that each pool can accept. The variable has the following structure:
 
 ```
 pool_configurations = {
@@ -43,6 +44,7 @@ variable "pool_config" {
     cidr                 = list(string)
     ram_share_principals = optional(list(string))
 
+    name                              = optional(string)
     locale                            = optional(string)
     allocation_default_netmask_length = optional(string)
     allocation_max_netmask_length     = optional(string)
@@ -63,26 +65,14 @@ variable "pool_config" {
 
 ## Implementation
 
+### Implied Pool Names & Descriptions
+
+By default, pool `Name` tags and pool descriptions are implied from the name-hierarchy structure of the pool. For example, a pool with two parents `us-east-1` and `dev` has an implied name and description value of `us-east-1/dev`. You can override either or both name & description at any pool level by specifying a `name` or `description`.
+
 ### Locales
 
 IPAM pools do not inherit attributes from their parent pools. Locales cannot change from parent to child. For that reason, after a pool in the `var.pool_configurations` variable defines a `locale` value, all other child pools have an `implied_locale` value.
 
-### Implied descriptions
-
-Descriptions of pools are implied from the name-hierarchy structure of the pool. For example, a pool with two parents `us-east-1` and `dev` has an `implied_description` value of `us-east-1/dev`. You can override the description at any pool level by specifying a description.
-
-`implied_desription = var.pool_config.description == null ? var.implied_description : var.pool_config.description`
-
 ### Operating Regions
 
 The IPAM `operating_region` variable must be set for the primary Region in your Terraform provider block and any Regions you want to set a `locale`. For that reason, the value of the `aws_vpc_ipam.operating_regions` variable is constructed by combining the  `pool_configurations` and `data.aws_region.current.name` attributes.
-
-## Examples of importing at multiple levels 
-
-**level 0 pool**: `terraform import module.basic.module.level_zero.aws_vpc_ipam_pool.sub ipam-pool-<>`
-
-**level 1 pool**: `terraform import module.basic.module.level_one["<>"].aws_vpc_ipam_pool.sub ipam-pool-<>`
-
-**level 2 pool**: `terraform import module.basic.module.level_two["<>/<>"].aws_vpc_ipam_pool.sub ipam-pool-<>`
-
-**level 3 pool**: `terraform import module.basic.module.level_three["<>/<>/<>"].aws_vpc_ipam_pool.sub ipam-pool-<>`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ minimum_pre_commit_version: "2.6.0"
 
 repos:
   - repo: https://github.com/aws-ia/pre-commit-configs
-    rev: 4385a8e38e25301855d7db66dfa7855849d63a08  # frozen: v1.3.1
+    rev: ce5b80d2643c3510bd17bb309cb767b6b21dc5ea  # frozen: 1.4
     hooks:
       - id: aws-ia-meta-hook

--- a/examples/single_scope_ipv4/main.tf
+++ b/examples/single_scope_ipv4/main.tf
@@ -19,6 +19,7 @@ module "basic" {
       sub_pools = {
 
         sandbox = {
+          name                 = "mysandbox"
           cidr                 = ["10.0.0.0/20"]
           ram_share_principals = var.sandbox_ou_arn
           allocation_resource_tags = {

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,4 @@
 locals {
-  # Example Pool Structure
-  # Top  0 - super cidr
-  # level 1 - region
-  # level 2 - env
-  # level 3 - business unit
-
   # if create_ipam is true use determine if public or private default scope should be used. if create_ipam is false use `var.ipam_scope_id`
   scope_id = var.create_ipam ? (
     var.ipam_scope_type == "private" ? aws_vpc_ipam.main[0].private_default_scope_id : aws_vpc_ipam.main[0].public_default_scope_id

--- a/modules/sub_pool/README.md
+++ b/modules/sub_pool/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.6.0 |
 
 ## Modules
 

--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -1,5 +1,6 @@
 locals {
   description = var.pool_config.description == null ? var.implied_description : var.pool_config.description
+  name        = var.pool_config.name == null ? var.implied_name : var.pool_config.name
 }
 
 resource "aws_vpc_ipam_pool" "sub" {
@@ -18,7 +19,7 @@ resource "aws_vpc_ipam_pool" "sub" {
   publicly_advertisable             = var.pool_config.publicly_advertisable
 
   tags = merge(var.pool_config.tags,
-  { Name = var.implied_name })
+  { Name = local.name })
 }
 
 resource "aws_vpc_ipam_pool_cidr" "sub" {


### PR DESCRIPTION
bringing in updates from #25 

fixes `name` parameter on sub_pools to allow for name overiding