### PR TITLE
Zero ram principals should not create ram share

### DIFF
--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -54,7 +54,7 @@ resource "aws_ram_resource_association" "sub" {
 }
 
 resource "aws_ram_principal_association" "sub" {
-  count = local.ram_share_enabled ? toset(var.pool_config.ram_share_principals) : []
+  for_each = local.ram_share_enabled ? toset(var.pool_config.ram_share_principals) : []
 
   principal          = each.key
   resource_share_arn = aws_ram_resource_share.sub[0].arn

--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -41,20 +41,20 @@ resource "aws_vpc_ipam_pool_cidr" "sub" {
 }
 
 resource "aws_ram_resource_share" "sub" {
-  count = try(length(var.pool_config.ram_share_principals), 0) > 0 ? 1 : 0
+  count = local.ram_share_enabled ? 1 : 0
 
   name = replace(var.implied_description, "/", "-")
 }
 
 resource "aws_ram_resource_association" "sub" {
-  count = try(length(var.pool_config.ram_share_principals), 0) > 0 ? 1 : 0
+  count = local.ram_share_enabled ? 1 : 0
 
   resource_arn       = aws_vpc_ipam_pool.sub.arn
   resource_share_arn = aws_ram_resource_share.sub[0].arn
 }
 
 resource "aws_ram_principal_association" "sub" {
-  count = try(length(var.pool_config.ram_share_principals), 0) > 0 ? toset(var.pool_config.ram_share_principals) : []
+  count = local.ram_share_enabled ? toset(var.pool_config.ram_share_principals) : []
 
   principal          = each.key
   resource_share_arn = aws_ram_resource_share.sub[0].arn


### PR DESCRIPTION
This will prevent creating a ram share if zero principals have been provided

This also frames the logic in the positive instead of the negative

i.e. if ram share enabled, then create

vs

if ram share principals is null, then do not create, else create.