### PR TITLE
always prefer pool_config.locale unless implied != "None"

### DIFF
--- a/examples/single_scope_ipv4/main.tf
+++ b/examples/single_scope_ipv4/main.tf
@@ -14,7 +14,6 @@ module "basic" {
     corporate-us-west-2 = {
       description = "2nd level, locale us-west-2 pool"
       cidr        = ["10.0.0.0/16", "10.1.0.0/16"]
-      locale      = "us-west-2"
 
       sub_pools = {
 
@@ -33,6 +32,7 @@ module "basic" {
             team_a = {
               cidr                 = ["10.1.0.0/24"]
               ram_share_principals = var.prod_account # prod account
+              locale               = "us-west-2"
             }
 
             team_b = {
@@ -42,7 +42,8 @@ module "basic" {
           }
         }
         prod = {
-          cidr = ["10.1.16.0/20"]
+          cidr   = ["10.1.16.0/20"]
+          locale = "us-west-2"
 
           sub_pools = {
             team_a = {

--- a/modules/sub_pool/README.md
+++ b/modules/sub_pool/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 
 ## Modules
 
@@ -35,7 +35,7 @@ No modules.
 | <a name="input_pool_config"></a> [pool\_config](#input\_pool\_config) | Configuration of the Pool you want to deploy. All aws\_vpc\_ipam\_pool arguments are available as well as ram\_share\_principals list and sub\_pools map (up to 3 levels). | <pre>object({<br>    cidr                 = list(string)<br>    ram_share_principals = optional(list(string))<br><br>    locale                            = optional(string)<br>    allocation_default_netmask_length = optional(string)<br>    allocation_max_netmask_length     = optional(string)<br>    allocation_min_netmask_length     = optional(string)<br>    auto_import                       = optional(string)<br>    aws_service                       = optional(string)<br>    description                       = optional(string)<br>    name                              = optional(string)<br>    publicly_advertisable             = optional(bool)<br><br>    allocation_resource_tags   = optional(map(string))<br>    tags                       = optional(map(string))<br>    cidr_authorization_context = optional(map(string))<br><br>    sub_pools = optional(any)<br>  })</pre> | n/a | yes |
 | <a name="input_source_ipam_pool_id"></a> [source\_ipam\_pool\_id](#input\_source\_ipam\_pool\_id) | IPAM parent pool ID to attach the pool to. | `string` | n/a | yes |
 | <a name="input_implied_description"></a> [implied\_description](#input\_implied\_description) | Description is implied from the pool tree name <parent>/<child> unless specified on the pool\_config. | `string` | `null` | no |
-| <a name="input_implied_locale"></a> [implied\_locale](#input\_implied\_locale) | Locale is implied from a parent pool even if another is specified. Its not possible to set child pools to different locales. | `string` | `null` | no |
+| <a name="input_implied_locale"></a> [implied\_locale](#input\_implied\_locale) | Locale is implied from a parent pool even if another is specified. Its not possible to set child pools to different locales. | `string` | `"None"` | no |
 | <a name="input_implied_name"></a> [implied\_name](#input\_implied\_name) | Name is implied from the pool tree name <parent>/<child> unless specified on the pool\_config. | `string` | `null` | no |
 
 ## Outputs

--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -9,7 +9,7 @@ resource "aws_vpc_ipam_pool" "sub" {
   source_ipam_pool_id = var.source_ipam_pool_id
 
   description                       = local.description
-  locale                            = var.implied_locale == null ? var.pool_config.locale : var.implied_locale
+  locale                            = var.implied_locale != "None" ? var.implied_locale : var.pool_config.locale
   allocation_default_netmask_length = var.pool_config.allocation_default_netmask_length
   allocation_max_netmask_length     = var.pool_config.allocation_max_netmask_length
   allocation_min_netmask_length     = var.pool_config.allocation_min_netmask_length

--- a/modules/sub_pool/variables.tf
+++ b/modules/sub_pool/variables.tf
@@ -38,7 +38,7 @@ variable "pool_config" {
 variable "implied_locale" {
   description = "Locale is implied from a parent pool even if another is specified. Its not possible to set child pools to different locales."
   type        = string
-  default     = null
+  default     = "None"
 }
 
 variable "implied_description" {


### PR DESCRIPTION
Closes: #32 

There was a bug that `implied_pool` was taking precent over an explicitly pass pool in many circumstances. Pool locales now accurately inherit from parents and child pools with explicit locales can be set