### PR TITLE
Fix ram share for top level pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ The IPAM `operating_region` variable must be set for the primary Region in your 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73.0 |
 
 ## Modules
 

--- a/modules/sub_pool/README.md
+++ b/modules/sub_pool/README.md
@@ -3,14 +3,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73.0 |
 
 ## Modules
 

--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -1,5 +1,5 @@
 locals {
-  description = var.pool_config.description == null ? var.implied_description : var.pool_config.description
+  description = var.pool_config.description == null ? replace(var.implied_description, "/", "-") : var.pool_config.description
 
   name = var.pool_config.name == null ? var.implied_name : var.pool_config.name
   tags = merge(var.pool_config.tags, {
@@ -45,7 +45,7 @@ resource "aws_vpc_ipam_pool_cidr" "sub" {
 resource "aws_ram_resource_share" "sub" {
   count = local.ram_share_enabled ? 1 : 0
 
-  name = replace(var.implied_description, "/", "-")
+  name = local.description
 
   tags = local.tags
 }


### PR DESCRIPTION
Since `implied_description` is not set for `level_zero`, plan fails when `top_ram_share_principals` is set with below error.

![image](https://user-images.githubusercontent.com/46478191/210711893-969b0e8a-8f57-4b1c-8402-37d60c19e041.png)

Sample code that fails.

```hcl
module "ipam" {
   source  = "aws-ia/ipam/aws"
   version = "~> 1.1.4"

  top_cidr                 = ["10.0.0.0/8"]
  top_name                 = "IPAM Top"
  top_description          = "IPAM Top Pool"
  top_ram_share_principals = ["arn:aws:organizations::123456789012:root/o-ab7cdefghi"] #root parent ou

  pool_configurations = {
    prd = {
      name        = "prd"
      description = "Pool for prd member accounts"
      cidr        = ["10.0.0.0/9"]
    }
    nonprd = {
      name        = "nonprd"
      description = "Pool for non prd member accounts"
      cidr        = ["10.128.0.0/9"]
    }
  }
}

```

Fix will make use of pool_config description (top_description) [https://github.com/aws-ia/terraform-aws-ipam/blob/a9afdd97c35a1ab71af9f2942cdc2ae2f751794f/main.tf#L53]  to name the ram resource share.