### PR TITLE
fix regression in ram share pool names

### DIFF
--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -45,7 +45,8 @@ resource "aws_vpc_ipam_pool_cidr" "sub" {
 resource "aws_ram_resource_share" "sub" {
   count = local.ram_share_enabled ? 1 : 0
 
-  name = local.description
+  # if a user specifies a var.pool.description must validate there is no / which is invalid for RAM names
+  name = replace(local.description, "/", "-")
 
   tags = local.tags
 }


### PR DESCRIPTION
closes: #49 

A regression was introduced in 1.1.5 where if a user specifies a pool_config description that includes a `/`, it will attempt to create a ram share with an invalid name