### PR TITLE
Allow ram shares to come from SSM params

### DIFF
--- a/modules/sub_pool/main.tf
+++ b/modules/sub_pool/main.tf
@@ -61,7 +61,7 @@ resource "aws_ram_resource_association" "sub" {
 }
 
 resource "aws_ram_principal_association" "sub" {
-  for_each = local.ram_share_enabled ? toset(var.pool_config.ram_share_principals) : []
+  for_each = local.ram_share_enabled ? nonsensitive(toset(var.pool_config.ram_share_principals)) : []
 
   principal          = each.key
   resource_share_arn = aws_ram_resource_share.sub[0].arn


### PR DESCRIPTION
Currently running into the following error because my ram shares are coming from SSM params:

```
  64:   for_each = local.ram_share_enabled ? toset(var.pool_config.ram_share_principals) : []
    ├────────────────
    │ local.ram_share_enabled is true
    │ var.pool_config.ram_share_principals is list of string with 1 element

Sensitive values, or values derived from sensitive values, cannot be used as
for_each arguments. If used, the sensitive value could be exposed as a
resource instance key.
```

This is a simple fix using "nonsensitive"